### PR TITLE
Bump build number by 1000 for compiler migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About leveldb
 
 Home: https://github.com/google/leveldb
 
-Package license: BSD
+Package license: BSD 3-Clause
 
 Feedstock license: BSD 3-Clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ test:
 about:
   home: https://github.com/google/leveldb
   license: BSD 3-Clause
+  license_file: LICENSE
   summary: A fast key-value storage library providing ordered mappings.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,7 @@ test:
   commands:
     - test -f ${PREFIX}/lib/libmemenv.a
     - test -f ${PREFIX}/lib/libleveldb.a
-    - test -f ${PREFIX}/lib/libleveldb.dylib            # [osx]
-    - test -f ${PREFIX}/lib/libleveldb.so               # [linux]
+    - test -f ${PREFIX}/lib/libleveldb${SHLIB_EXT}
 
 about:
   home: https://github.com/google/leveldb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
 
 about:
   home: https://github.com/google/leveldb
-  license: BSD
+  license: BSD 3-Clause
   summary: A fast key-value storage library providing ordered mappings.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ hash }}
 
 build:
-  number: 0
+  number: 1001
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
Follow-up to PR ( https://github.com/conda-forge/leveldb-feedstock/pull/7 )

Bump once more for `conda-build` 3 and new `compiler` syntax usage for the legacy compiler build. Added a few other minor fixes to the package.

cc @xhochy

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
